### PR TITLE
Add method to render component in the place of a slot

### DIFF
--- a/src/NodeComponent.ts
+++ b/src/NodeComponent.ts
@@ -73,4 +73,17 @@ export abstract class NodeComponent<T extends Node> {
         this.node.addEventListener(type, e => listener(e, this), c);
         return this;
     }
+
+	/**
+	 * Render this component in the place of a `<slot name="…"></slot>`.
+	 * If multiple slots with the same name are found, they will all be used.
+	 * @param slot The slot name
+	 * @param [parent] The parent element within to search for slots. Defaults to `document`
+	 */
+	public slot(slot: string, parent: ParentNode = document) {
+		const slotNodes = parent.querySelectorAll(`slot[name="${slot}"]`);
+		for (const slotNode of slotNodes)
+			slotNode.replaceWith(this.node);
+		return this;
+	}
 }


### PR DESCRIPTION
Example usage:
```js
const container = new Component("div").html(`
    <div>
        <h1><slot name="title"></slot></h1>
        <div><slot name="button"></slot></div>
    </div>
`);
new TextComponent("Hello World").slot("title");
new Component("button").text("Button").slot("button", container.node);
```