### PR TITLE
Append HTML string literals with components

### DIFF
--- a/src/DocumentComponent.ts
+++ b/src/DocumentComponent.ts
@@ -23,4 +23,16 @@ export class DocumentComponent extends NodeComponent<DocumentFragment> {
     public constructor(html?: string) {
         super(html ? document.createRange().createContextualFragment(html) : document.createDocumentFragment());
     }
+
+    /**
+     * Template literal tag function that accepts HTML code with components in a
+     * string literal
+     */
+    public static tag(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): DocumentComponent {
+        const idPrefix = "tag-" + crypto.randomUUID() + "-";
+        const doc = new DocumentComponent(strings.reduce((acc, str, index) => acc += `${str}${index < components.length ? `<slot name="${idPrefix}${index + 1}"></slot>` : ""}`, ""));
+        for (const [index, component] of components.entries())
+            component.slot(idPrefix + index, doc.node);
+        return doc;
+    }
 }

--- a/src/DocumentComponent.ts
+++ b/src/DocumentComponent.ts
@@ -29,7 +29,7 @@ export class DocumentComponent extends NodeComponent<DocumentFragment> {
      * string literal
      */
     public static tag(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): DocumentComponent {
-        const idPrefix = "tag-" + crypto.randomUUID() + "-";
+        const idPrefix = `tag-${crypto.randomUUID()}-`;
         const doc = new DocumentComponent(strings.reduce((acc, str, index) => acc += `${str}${index < components.length ? `<slot name="${idPrefix}${index - 1}"></slot>` : ""}`, ""));
         for (const [index, component] of components.entries())
             component.slot(idPrefix + index, doc.node);

--- a/src/DocumentComponent.ts
+++ b/src/DocumentComponent.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright © 2024 Cloudnode OÜ
+ *
+ * This file is part of @cldn/components.
+ *
+ * \@cldn/components is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * \@cldn/components is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with @cldn/components.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
 import {NodeComponent} from "./NodeComponent.js";
 
 /**

--- a/src/DocumentComponent.ts
+++ b/src/DocumentComponent.ts
@@ -30,7 +30,7 @@ export class DocumentComponent extends NodeComponent<DocumentFragment> {
      */
     public static tag(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): DocumentComponent {
         const idPrefix = "tag-" + crypto.randomUUID() + "-";
-        const doc = new DocumentComponent(strings.reduce((acc, str, index) => acc += `${str}${index < components.length ? `<slot name="${idPrefix}${index + 1}"></slot>` : ""}`, ""));
+        const doc = new DocumentComponent(strings.reduce((acc, str, index) => acc += `${str}${index < components.length ? `<slot name="${idPrefix}${index - 1}"></slot>` : ""}`, ""));
         for (const [index, component] of components.entries())
             component.slot(idPrefix + index, doc.node);
         return doc;

--- a/src/DocumentComponent.ts
+++ b/src/DocumentComponent.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with @cldn/components.
  * If not, see <https://www.gnu.org/licenses/>.
  */
-import {NodeComponent} from "./NodeComponent.js";
+import {NodeComponent} from "./index.js";
 
 /**
  * A {@link !DocumentFragment} component

--- a/src/DocumentComponent.ts
+++ b/src/DocumentComponent.ts
@@ -1,0 +1,10 @@
+import {NodeComponent} from "./NodeComponent.js";
+
+/**
+ * A {@link !DocumentFragment} component
+ */
+export class DocumentComponent extends NodeComponent<DocumentFragment> {
+    public constructor(html?: string) {
+        super(html ? document.createRange().createContextualFragment(html) : document.createDocumentFragment());
+    }
+}

--- a/src/DocumentComponent.ts
+++ b/src/DocumentComponent.ts
@@ -30,7 +30,7 @@ export class DocumentComponent extends NodeComponent<DocumentFragment> {
      */
     public static tag(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): DocumentComponent {
         const idPrefix = `tag-${crypto.randomUUID()}-`;
-        const doc = new DocumentComponent(strings.reduce((acc, str, index) => acc += `${str}${index < components.length ? `<slot name="${idPrefix}${index - 1}"></slot>` : ""}`, ""));
+        const doc = new DocumentComponent(strings.reduce((acc, str, index) => acc + `${str}${index < components.length ? `<slot name="${idPrefix}${index - 1}"></slot>` : ""}`, ""));
         for (const [index, component] of components.entries())
             component.slot(idPrefix + index, doc.node);
         return doc;

--- a/src/ElementComponent.ts
+++ b/src/ElementComponent.ts
@@ -15,6 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 import {NodeComponent} from "./NodeComponent.js";
+import {DocumentComponent} from "./DocumentComponent.js";
 
 /**
  * Non-readonly non-method keys
@@ -132,6 +133,23 @@ export abstract class ElementComponent<T extends Element> extends NodeComponent<
     public html(html: string) {
         this.node.innerHTML = html;
         return this;
+    }
+
+    /**
+     * Template literal tag function that accepts HTML code with components in a
+     * string literal and returns a {@link DocumentComponent}
+     */
+    public tag(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): DocumentComponent {
+        const ids = Array.from({length: components.length}, () => crypto.randomUUID());
+        const doc = new DocumentComponent(strings.reduce((acc, str, index) => {
+            acc += str;
+            if (index < components.length)
+                acc += `<slot name="${ids[index]}"></slot>`;
+            return acc;
+        }, ""));
+        for (const [index, component] of components.entries())
+            component.slot(ids[index]!, doc.node);
+        return doc;
     }
 
     /**

--- a/src/ElementComponent.ts
+++ b/src/ElementComponent.ts
@@ -51,18 +51,6 @@ export abstract class ElementComponent<T extends Element> extends NodeComponent<
     }
 
     /**
-     * Template literal tag function that accepts HTML code with components in a
-     * string literal and returns a {@link DocumentComponent}
-     */
-    public static tag(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): DocumentComponent {
-        const idPrefix = "tag-" + crypto.randomUUID() + "-";
-        const doc = new DocumentComponent(strings.reduce((acc, str, index) => acc += `${str}${index < components.length ? `<slot name="${idPrefix}${index + 1}"></slot>` : ""}`, ""));
-        for (const [index, component] of components.entries())
-            component.slot(idPrefix + index, doc.node);
-        return doc;
-    }
-
-    /**
      * Insert component before the first child
      */
     public prepend(...components: NodeComponent<any>[]) {
@@ -153,7 +141,7 @@ export abstract class ElementComponent<T extends Element> extends NodeComponent<
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals Template literals (Template strings) - MDN
      */
     public html(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): this {
-        return this.append(ElementComponent.tag(strings, ...components));
+        return this.append(DocumentComponent.tag(strings, ...components));
     }
 
     /**

--- a/src/ElementComponent.ts
+++ b/src/ElementComponent.ts
@@ -145,8 +145,18 @@ export abstract class ElementComponent<T extends Element> extends NodeComponent<
     }
 
     /**
-     * Append HTML
-     * @example component.html`<div>${component}</div>`
+     * Append HTML.
+     *
+     * Any components (provided as `${...}` inside the HTML string literal)
+     * remain fully functional and are appended (not just as HTML).
+     * @example
+     * component.html`<div>${new Component("button")
+     *      .text("Click me")
+     *      .on("click", () => console.log("clicked"))
+     * }</div>`
+     * // Event listeners etc. are preserved.
+     * // Note the lack of parentheses.
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals Template literals (Template strings) - MDN
      */
     public html(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): this {
         return this.append(this.tag(strings, ...components));

--- a/src/ElementComponent.ts
+++ b/src/ElementComponent.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with @cldn/components.
  * If not, see <https://www.gnu.org/licenses/>.
  */
-import {NodeComponent, DocumentComponent} from "./index.js";
+import {DocumentComponent, NodeComponent} from "./index.js";
 
 /**
  * Non-readonly non-method keys
@@ -48,6 +48,18 @@ export abstract class ElementComponent<T extends Element> extends NodeComponent<
      */
     protected constructor(element: T) {
         super(element);
+    }
+
+    /**
+     * Template literal tag function that accepts HTML code with components in a
+     * string literal and returns a {@link DocumentComponent}
+     */
+    public static tag(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): DocumentComponent {
+        const idPrefix = "tag-" + crypto.randomUUID() + "-";
+        const doc = new DocumentComponent(strings.reduce((acc, str, index) => acc += `${str}${index < components.length ? `<slot name="${idPrefix}${index + 1}"></slot>` : ""}`, ""));
+        for (const [index, component] of components.entries())
+            component.slot(idPrefix + index, doc.node);
+        return doc;
     }
 
     /**
@@ -124,23 +136,6 @@ export abstract class ElementComponent<T extends Element> extends NodeComponent<
     public removeAttr(name: string) {
         this.node.removeAttribute(name);
         return this;
-    }
-
-    /**
-     * Template literal tag function that accepts HTML code with components in a
-     * string literal and returns a {@link DocumentComponent}
-     */
-    public static tag(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): DocumentComponent {
-        const ids = Array.from({length: components.length}, () => crypto.randomUUID());
-        const doc = new DocumentComponent(strings.reduce((acc, str, index) => {
-            acc += str;
-            if (index < components.length)
-                acc += `<slot name="${ids[index]}"></slot>`;
-            return acc;
-        }, ""));
-        for (const [index, component] of components.entries())
-            component.slot(ids[index]!, doc.node);
-        return doc;
     }
 
     /**

--- a/src/ElementComponent.ts
+++ b/src/ElementComponent.ts
@@ -131,7 +131,7 @@ export abstract class ElementComponent<T extends Element> extends NodeComponent<
      * Template literal tag function that accepts HTML code with components in a
      * string literal and returns a {@link DocumentComponent}
      */
-    public tag(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): DocumentComponent {
+    public static tag(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): DocumentComponent {
         const ids = Array.from({length: components.length}, () => crypto.randomUUID());
         const doc = new DocumentComponent(strings.reduce((acc, str, index) => {
             acc += str;
@@ -159,7 +159,7 @@ export abstract class ElementComponent<T extends Element> extends NodeComponent<
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals Template literals (Template strings) - MDN
      */
     public html(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): this {
-        return this.append(this.tag(strings, ...components));
+        return this.append(ElementComponent.tag(strings, ...components));
     }
 
     /**

--- a/src/ElementComponent.ts
+++ b/src/ElementComponent.ts
@@ -138,7 +138,7 @@ export abstract class ElementComponent<T extends Element> extends NodeComponent<
      * }</div>`
      * // Event listeners etc. are preserved.
      * // Note the lack of parentheses.
-     * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals Template literals (Template strings) - MDN
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals Template literals (Template strings) - MDN}
      */
     public html(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): this {
         return this.append(DocumentComponent.tag(strings, ...components));

--- a/src/ElementComponent.ts
+++ b/src/ElementComponent.ts
@@ -128,14 +128,6 @@ export abstract class ElementComponent<T extends Element> extends NodeComponent<
     }
 
     /**
-     * Set inner HTML
-     */
-    public html(html: string) {
-        this.node.innerHTML = html;
-        return this;
-    }
-
-    /**
      * Template literal tag function that accepts HTML code with components in a
      * string literal and returns a {@link DocumentComponent}
      */
@@ -150,6 +142,14 @@ export abstract class ElementComponent<T extends Element> extends NodeComponent<
         for (const [index, component] of components.entries())
             component.slot(ids[index]!, doc.node);
         return doc;
+    }
+
+    /**
+     * Append HTML
+     * @example component.html`<div>${component}</div>`
+     */
+    public html(strings: TemplateStringsArray, ...components: NodeComponent<any>[]): this {
+        return this.append(this.tag(strings, ...components));
     }
 
     /**

--- a/src/ElementComponent.ts
+++ b/src/ElementComponent.ts
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with @cldn/components.
  * If not, see <https://www.gnu.org/licenses/>.
  */
-import {NodeComponent} from "./NodeComponent.js";
-import {DocumentComponent} from "./DocumentComponent.js";
+import {NodeComponent, DocumentComponent} from "./index.js";
 
 /**
  * Non-readonly non-method keys

--- a/src/NodeComponent.ts
+++ b/src/NodeComponent.ts
@@ -34,6 +34,15 @@ export abstract class NodeComponent<T extends Node> {
 	}
 
 	/**
+	 * Run a function in the context of this component
+	 * @param fn Provides this component as the first argument and `this`.
+	 */
+	public context(fn: (this: this, component: this) => this): this {
+		fn.call(this, this);
+		return this;
+	}
+
+	/**
 	 * Insert component after the last child
 	 */
 	public append(...components: NodeComponent<any>[]) {

--- a/src/NodeComponent.ts
+++ b/src/NodeComponent.ts
@@ -86,4 +86,13 @@ export abstract class NodeComponent<T extends Node> {
 			slotNode.replaceWith(this.node);
 		return this;
 	}
+
+	/**
+	 * Empty the component (remove children)
+	 */
+	public empty() {
+		while (this.node.firstChild)
+			this.node.removeChild(this.node.firstChild);
+		return this;
+	}
 }

--- a/src/TextComponent.ts
+++ b/src/TextComponent.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with @cldn/components.
  * If not, see <https://www.gnu.org/licenses/>.
  */
-import {NodeComponent} from "./NodeComponent.js";
+import {NodeComponent} from "./index.js";
 
 /**
  * A text node component

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 export {NodeComponent} from "./NodeComponent.js";
+export {DocumentComponent} from "./DocumentComponent.js";
 export {TextComponent} from "./TextComponent.js";
 export {ElementComponent} from "./ElementComponent.js";
 export {Component} from "./Component.js";


### PR DESCRIPTION
Adds handling for HTML template literals with components.

The `ElementComponent#html()` method is a template literal tag function.

Example usage:
```ts
const button = new Component("button")
    .text("Click me")
    .on("click", () => console.log("clicked"));
new Component("div")
    .html`<h1>Hello world</h1>`
    .html`<div>
        <div>
            ${button}
        </div>
        <p>Unlike <code>element.innerHTML = "..."</code>, event listeners are preserved.</p>
    </div>`;
```

`.tag()` can be used the same way, except the return value is `DocumentComponent`.
Example:
```ts
new Component("div")
    c.append(DocumentComponent.tag`<div>${button}</div>`);
```

This is a breaking change. For the old behaviour of `.html()` that removes the component's children, call the `.empty()` method first.

I sneaked in another method, `NodeComponent#context()`, which lets you access this component's instance in a function without breaking the chaining.